### PR TITLE
Repair patch

### DIFF
--- a/patches/generic-php-config-loader.patch
+++ b/patches/generic-php-config-loader.patch
@@ -1,6 +1,6 @@
---- a/Loader/PhpFileLoader.php
-+++ b/Loader/PhpFileLoader.php
-@@ -64,7 +64,11 @@ class PhpFileLoader extends FileLoader
+--- /dev/null
++++ ../Loader/PhpFileLoader.php
+@@ -64,7 +64,11 @@
              $callback = $load($path, $this->env);
 
              if (\is_object($callback) && \is_callable($callback)) {
@@ -13,7 +13,7 @@
              }
          } finally {
              $this->instanceof = [];
-@@ -118,25 +122,26 @@ class PhpFileLoader extends FileLoader
+@@ -121,25 +125,26 @@
              }
              $type = $reflectionType->getName();
 
@@ -58,3 +58,16 @@
 +                }
              }
          }
+
+@@ -163,9 +168,11 @@
+             throw new \LogicException('You cannot use the config builder as the Config component is not installed. Try running "composer require symfony/config".');
+         }
+
++
+         if (null === $this->generator) {
+             throw new \LogicException('You cannot use the ConfigBuilders without providing a class implementing ConfigBuilderGeneratorInterface.');
+         }
++
+
+         // If class exists and implements ConfigBuilderInterface
+         if (class_exists($namespace) && is_subclass_of($namespace, ConfigBuilderInterface::class)) {

--- a/patches/generic-php-config-loader.patch
+++ b/patches/generic-php-config-loader.patch
@@ -1,5 +1,5 @@
---- /dev/null
-+++ ../Loader/PhpFileLoader.php
+--- a/Loader/PhpFileLoader.php
++++ b/Loader/PhpFileLoader.php
 @@ -64,7 +64,11 @@
              $callback = $load($path, $this->env);
 

--- a/patches/generic-php-config-loader.patch
+++ b/patches/generic-php-config-loader.patch
@@ -1,6 +1,6 @@
---- /dev/null
-+++ ../Loader/PhpFileLoader.php
-@@ -64,7 +64,11 @@
+--- a/Loader/PhpFileLoader.php
++++ b/Loader/PhpFileLoader.php
+@@ -64,7 +64,11 @@ class PhpFileLoader extends FileLoader
              $callback = $load($path, $this->env);
 
              if (\is_object($callback) && \is_callable($callback)) {
@@ -13,7 +13,7 @@
              }
          } finally {
              $this->instanceof = [];
-@@ -121,25 +125,26 @@
+@@ -118,25 +122,26 @@ class PhpFileLoader extends FileLoader
              }
              $type = $reflectionType->getName();
 
@@ -58,16 +58,3 @@
 +                }
              }
          }
-
-@@ -163,9 +168,11 @@
-             throw new \LogicException('You cannot use the config builder as the Config component is not installed. Try running "composer require symfony/config".');
-         }
-
-+
-         if (null === $this->generator) {
-             throw new \LogicException('You cannot use the ConfigBuilders without providing a class implementing ConfigBuilderGeneratorInterface.');
-         }
-+
-
-         // If class exists and implements ConfigBuilderInterface
-         if (class_exists($namespace) && is_subclass_of($namespace, ConfigBuilderInterface::class)) {


### PR DESCRIPTION
This patch did not install.

```
Gathering patches for root package.
Gathering patches for dependencies. This might take a minute.
Found 1 patches for symfony/dependency-injection.
  - Installing symfony/dependency-injection (v6.1.12): Extracting archive
Executing async command (CWD): '/usr/bin/unzip' -qq '/Users/antonevers/web/AntonEvers/monorepo-builder/vendor/composer/tmp-994403dcf948f97b159c6e40ba3dad06' -d '/Users/antonevers/web/AntonEvers/monorepo-builder/vendor/composer/788c53c7'
Executing async command (CWD): rm -rf '/Users/antonevers/web/AntonEvers/monorepo-builder/vendor/composer/788c53c7'
> post-package-install: cweagans\Composer\Patches->postInstall
  - Applying patches for symfony/dependency-injection
    https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch (0)
Downloading https://raw.githubusercontent.com/symplify/vendor-patch-files/main/patches/generic-php-config-loader.patch
patch '-p1' --no-backup-if-mismatch -d '/Users/antonevers/web/AntonEvers/monorepo-builder/vendor/symfony/dependency-injection' < '/var/folders/p6/y1jmbsqx1kv6lhwntxczrv600000gn/T/63f8a0115e465.patch'
Executing command (CWD): patch '-p1' --no-backup-if-mismatch -d '/Users/antonevers/web/AntonEvers/monorepo-builder/vendor/symfony/dependency-injection' < '/var/folders/p6/y1jmbsqx1kv6lhwntxczrv600000gn/T/63f8a0115e465.patch'
patching file 'Loader/PhpFileLoader.php'
Patch creates file that already exists!  Assume -R? [y]
```
After this change, it does install.
I have also removed the whitespace changes at the end of the patch that were not adding anything functional.